### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dependabot-merge.yml
+++ b/.github/workflows/dependabot-merge.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   auto-merge:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/gioxx/curl-ip/security/code-scanning/2](https://github.com/gioxx/curl-ip/security/code-scanning/2)

To fix the issue, add a `permissions` block at the workflow level (applies to all jobs) or at the job level (specific to the `auto-merge` job). Since the workflow involves checking out the repository and merging pull requests, the minimal required permissions are `contents: read` and `pull-requests: write`. These permissions allow the workflow to read repository contents and merge pull requests without granting unnecessary write access to other resources.

The `permissions` block should be added at the workflow level for simplicity, as there is only one job in this workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
